### PR TITLE
conf: code-climate coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
     - run: cc-test-reporter before-build
-    - run: cc-test-reporter after-build
+    - run: cc-test-reporter after-build --coverage-input-type lcov
     - name: Send coverage report to Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       uses: amancevice/setup-code-climate@v0
       with:
         cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
-    - run: cc-test-reporter before-build
     - run: cc-test-reporter after-build --coverage-input-type lcov
     - name: Send coverage report to Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,11 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Send coverage report to Code Climate
-      uses: aktions/codeclimate-test-reporter@v1
+      uses: amancevice/setup-code-climate@v0
       with:
-        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
-        command: after-build --coverage-input-type lcov
+        cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
+    - run: cc-test-reporter before-build
+    - run: cc-test-reporter after-build
     - name: Send coverage report to Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,14 @@ jobs:
         mongodb-version: '4.4'
     - name: Run tests
       run: bundle exec rake
-    - name: Coveralls
+    - name: Send coverage report to Code Climate
+      uses: aktions/codeclimate-test-reporter@v1
+      with:
+        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
+        command: after-build --coverage-input-type lcov
+    - name: Send coverage report to Coveralls
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Rubocop
+    - name: Run RuboCop
       run: bundle exec rubocop


### PR DESCRIPTION
Closes: n/a

# Goal
Add test-coverage to Code Climate results.

# Approach
1. Apply [Setup Code Climate](https://github.com/marketplace/actions/setup-code-climate) Action.
2. Add `CC_TEST_REPORTER_ID`.
3. Specify `lcov` report type.
4. Remove unused `before-build`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
