### PR TITLE
conf: optimize gemspec and README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-Closes: #
+# Closes: #
 
-# Goal
+## Goal
 What problem does this pull request solve? This should be close to the goal of the issue this pull request addresses.
 
-# Approach
+## Approach
 1. **Describe, in numbered steps, the approach you chose** to solve the above problem.
     1. This will help code reviewers get oriented quickly.
     2. It will also document for future maintainers exactly what changed (and why) when this PR was merged.

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@
 
 source 'https://rubygems.org'
 gemspec
+
+gem 'rake', '>= 12.3.3', '~> 13.0'
+gem 'rspec', '~> 3'
+gem 'rubocop', '< 1.24'
+gem 'rubocop-rake', '~> 0'
+gem 'rubocop-rspec', '~> 2'
+gem 'simplecov', '~> 0.18'
+gem 'simplecov-lcov', '~> 0.8'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HitCounter
 
 [![Build status](https://github.com/FoveaCentral/hit_counter/workflows/test/badge.svg)](https://github.com/FoveaCentral/hit_counter/actions/workflows/test.yml)
-[![Code Climate](https://codeclimate.com/github/FoveaCentral/hit_counter.png)](https://codeclimate.com/github/FoveaCentral/hit_counter)
+[![Code Climate](https://codeclimate.com/github/FoveaCentral/hit_counter.svg)](https://codeclimate.com/github/FoveaCentral/hit_counter)
 [![Coveralls](https://coveralls.io/repos/FoveaCentral/hit_counter/badge.svg?branch=master&service=github)](https://coveralls.io/github/FoveaCentral/hit_counter?branch=master)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5375/badge)](https://bestpractices.coreinfrastructure.org/projects/5375)
 [![Gem Version](https://badge.fury.io/rb/hit_counter.svg)](https://badge.fury.io/rb/hit_counter)

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -14,14 +14,6 @@ Gem::Specification.new do |s|
   s.cert_chain = ['certs/ivanoblomov.pem']
   s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME =~ /gem\z/
 
-  s.add_development_dependency 'rake', '>= 12.3.3', '~> 13.0'
-  s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rubocop', '< 1.24'
-  s.add_development_dependency 'rubocop-rake', '~> 0'
-  s.add_development_dependency 'rubocop-rspec', '~> 2'
-  s.add_development_dependency 'simplecov', '~> 0.18'
-  s.add_development_dependency 'simplecov-lcov', '~> 0.8'
-
   s.add_runtime_dependency 'addressable', '~> 2'
   s.add_runtime_dependency 'bson_ext', '~> 1'
   s.add_runtime_dependency 'mongoid', '~> 7'

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -28,9 +28,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rmagick', '>= 2', '< 5'
 
   s.files         = `git ls-files`.split "\n"
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split "\n"
-  s.executables   = `git ls-files -- bin/*`.split("\n")
-                                           .map { |f| File.basename f }
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5'
 end


### PR DESCRIPTION
# Closes: n/a

## Goal
Optimize the `gemspec` and README.

## Approach
1. Optimize the `gemspec` by:
    a. moving development dependencies to `Gemfile`
    b. removing the unused directives `test_files` and `executables `
2. Optimize the README by using only `svg` badges.
3. Made "Closes:" the main header in pull-requests.

## Notes
Inspired by https://github.com/FoveaCentral/google_maps_geocoder/pull/73 and https://github.com/FoveaCentral/google_maps_geocoder/pull/80.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
