### PR TITLE
CI: inch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,16 @@ jobs:
         mongodb-version: '4.4'
     - name: Run tests
       run: bundle exec rake
-    - name: Send coverage report to Code Climate
+    - name: Send Code Climate coverage
       uses: amancevice/setup-code-climate@v0
       with:
         cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
     - run: cc-test-reporter after-build --coverage-input-type lcov
-    - name: Send coverage report to Coveralls
+    - name: Send Coveralls coverage
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run RuboCop
       run: bundle exec rubocop
+    - name: Run Inch
+      run: bundle exec inch --pedantic

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'inch', '~> 0.8'
 gem 'pry', '~> 0.14.1'
 gem 'rake', '>= 12.3.3', '~> 13.0'
 gem 'rspec', '~> 3'

--- a/lib/hit_counter.rb
+++ b/lib/hit_counter.rb
@@ -24,6 +24,8 @@ class HitCounter
   # If the URI library can parse the value and the scheme is valid, then we
   # assume the url is valid.
   class UrlValidator < ActiveModel::EachValidator
+    private
+
     def validate_each(record, attribute, value)
       uri = Addressable::URI.parse value
       raise Addressable::URI::InvalidURIError unless %w[http https].include?(
@@ -116,6 +118,7 @@ class HitCounter
     save
   end
 
+  # Defines the available image styles as an array. Add yours to the end.
   STYLES = %w[odometer scout celtic].freeze
 
   private_class_method def self.cat_image(number, style_index, images = Magick::ImageList.new)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,6 @@
 
 # Ruby version of that old 90s chestnut, <BLINK>the web-site hit counter</BLINK>
 class HitCounter
+  # This gem's version
   VERSION = '0.1.4' unless defined?(HitCounter::VERSION)
 end


### PR DESCRIPTION
# Closes: n/a

## Goal
This doesn't replace http://Inch-CI.org (since no equivalent apparently exists), but it does run `inch` on CI as part of the GitHub Action.

## Approach
1. Add `inch` to `Gemfile`.
2. Have test workflow run `inch --pedantic`.
3. Fix warnings.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
