### PR TITLE
doc: updated best-practices URLs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,9 +1,4 @@
 name: analyze
-on:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
 permissions: read-all
 jobs:
   scorecard:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,6 @@
 name: analyze
+on:
+  push:
 permissions: read-all
 jobs:
   scorecard:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,9 +1,9 @@
-name: analyze
+name: Analyze
 on:
   push:
 permissions: read-all
 jobs:
-  scorecard:
+  Scorecard:
     environment: staging
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 on:
   push:
 permissions: read-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,4 @@
 name: test
-on:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+on:
+  push:
 permissions: read-all
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://github.com/FoveaCentral/hit_counter/workflows/test/badge.svg)](https://github.com/FoveaCentral/hit_counter/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/FoveaCentral/hit_counter.svg)](https://codeclimate.com/github/FoveaCentral/hit_counter)
 [![Coveralls](https://coveralls.io/repos/FoveaCentral/hit_counter/badge.svg?branch=master&service=github)](https://coveralls.io/github/FoveaCentral/hit_counter?branch=master)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5375/badge)](https://bestpractices.coreinfrastructure.org/projects/5375)
+[![CII Best Practices](https://www.bestpractices.dev/en/projects/5375/badge)](https://www.bestpractices.dev/en/projects/5375)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FoveaCentral/hit_counter/badge)](https://scorecard.dev/viewer/?uri=github.com/FoveaCentral/hit_counter)
 [![Gem Version](https://badge.fury.io/rb/hit_counter.svg)](https://badge.fury.io/rb/hit_counter)
 


### PR DESCRIPTION
# Re: #48

## Goal
Address [security issues](https://github.com/FoveaCentral/hit_counter/security/code-scanning).

## Approach
1. Update best-practices URLs to address https://github.com/FoveaCentral/hit_counter/security/code-scanning/2.
2. Disable `paths-ignore` to address https://github.com/FoveaCentral/hit_counter/security/code-scanning/1.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
