### PR TITLE
conf: Scorecard runs on default branch only

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,6 +4,7 @@ on:
 permissions: read-all
 jobs:
   Scorecard:
+    if: github.ref_name == github.event.repository.default_branch
     environment: staging
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Closes: n/a

## Goal
Disable Scorecard outside of default branch.

## Approach
1. Wrap Scorecard job in a conditional:
    ```ruby
    if: github.ref_name == github.event.repository.default_branch
    ```

Signed-off-by: Roderick Monje <rod@foveacentral.com>
