### PR TITLE
conf: reduce gem size

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,3 @@
-lib/**/*.rb
-bin/*
-- 
-features/**/*.feature
-LICENSE.txt
+# see https://github.com/ruby/rdoc/blob/master/.document
+*.md
+lib

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -19,7 +19,68 @@ Gem::Specification.new do |s|
   s.add_dependency 'mongoid'
   s.add_dependency 'rmagick'
 
-  s.files         = `git ls-files`.split "\n"
+  s.files = %w[
+    .document
+    .github/CODEOWNERS
+    .github/ISSUE_TEMPLATE/bug_report.md
+    .github/ISSUE_TEMPLATE/feature_request.md
+    .github/ISSUE_TEMPLATE/task.md
+    .github/PULL_REQUEST_TEMPLATE.md
+    .github/dependabot.yml
+    .github/workflows/push.yml
+    .github/workflows/scorecard.yml
+    .github/workflows/test.yml
+    .gitignore
+    .rspec
+    .rubocop.yml
+    .simplecov
+    CODE_OF_CONDUCT.md
+    CONTRIBUTING.md
+    Gemfile
+    LICENSE.txt
+    README.md
+    Rakefile
+    SECURITY.md
+    certs/ivanoblomov.pem
+    config/initializers/mime_types.rb
+    config/mongoid.yml
+    hit_counter.gemspec
+    lib/hit_counter.rb
+    lib/tasks/install.rake
+    lib/version.rb
+    public/images/digits/celtic/0.png
+    public/images/digits/celtic/1.png
+    public/images/digits/celtic/2.png
+    public/images/digits/celtic/3.png
+    public/images/digits/celtic/4.png
+    public/images/digits/celtic/5.png
+    public/images/digits/celtic/6.png
+    public/images/digits/celtic/7.png
+    public/images/digits/celtic/8.png
+    public/images/digits/celtic/9.png
+    public/images/digits/odometer/0.png
+    public/images/digits/odometer/1.png
+    public/images/digits/odometer/2.png
+    public/images/digits/odometer/3.png
+    public/images/digits/odometer/4.png
+    public/images/digits/odometer/5.png
+    public/images/digits/odometer/6.png
+    public/images/digits/odometer/7.png
+    public/images/digits/odometer/8.png
+    public/images/digits/odometer/9.png
+    public/images/digits/scout/0.png
+    public/images/digits/scout/1.png
+    public/images/digits/scout/2.png
+    public/images/digits/scout/3.png
+    public/images/digits/scout/4.png
+    public/images/digits/scout/5.png
+    public/images/digits/scout/6.png
+    public/images/digits/scout/7.png
+    public/images/digits/scout/8.png
+    public/images/digits/scout/9.png
+    spec/lib/hit_counter_spec.rb
+    spec/spec_helper.rb
+  ]
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 3.1'
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |s|
     public/images/digits/scout/8.png
     public/images/digits/scout/9.png
   ]
-  s.require_paths = ['lib']
   s.required_ruby_version = '>= 3.1'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -3,7 +3,7 @@
 require File.expand_path 'lib/version', __dir__
 Gem::Specification.new do |s|
   s.name = 'hit_counter'
-  s.version = HitCounter::VERSION.dup
+  s.version = '1.0.0'
   s.licenses = ['MIT']
   s.summary = 'Self-hosted Ruby version of that old 90s chestnut, the web-site hit counter.'
   s.description = 'Why roast this chestnut by that open fire, you ask? Cause ' \
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
     config/mongoid.yml
     lib/hit_counter.rb
     lib/tasks/install.rake
-    lib/version.rb
     public/images/digits/celtic/0.png
     public/images/digits/celtic/1.png
     public/images/digits/celtic/2.png

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require File.expand_path 'lib/version', __dir__
 Gem::Specification.new do |s|
   s.name = 'hit_counter'
   s.version = '1.0.0'

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -20,31 +20,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'rmagick'
 
   s.files = %w[
-    .document
-    .github/CODEOWNERS
-    .github/ISSUE_TEMPLATE/bug_report.md
-    .github/ISSUE_TEMPLATE/feature_request.md
-    .github/ISSUE_TEMPLATE/task.md
-    .github/PULL_REQUEST_TEMPLATE.md
-    .github/dependabot.yml
-    .github/workflows/push.yml
-    .github/workflows/scorecard.yml
-    .github/workflows/test.yml
-    .gitignore
-    .rspec
-    .rubocop.yml
-    .simplecov
-    CODE_OF_CONDUCT.md
-    CONTRIBUTING.md
     Gemfile
-    LICENSE.txt
-    README.md
     Rakefile
-    SECURITY.md
-    certs/ivanoblomov.pem
     config/initializers/mime_types.rb
     config/mongoid.yml
-    hit_counter.gemspec
     lib/hit_counter.rb
     lib/tasks/install.rake
     lib/version.rb
@@ -78,8 +57,6 @@ Gem::Specification.new do |s|
     public/images/digits/scout/7.png
     public/images/digits/scout/8.png
     public/images/digits/scout/9.png
-    spec/lib/hit_counter_spec.rb
-    spec/spec_helper.rb
   ]
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 3.1'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# Self-hosted Ruby version of that old 90s chestnut, <BLINK>the web-site hit counter</BLINK>
-class HitCounter
-  # This gem's version
-  VERSION = '1.0.0' unless defined?(HitCounter::VERSION)
-end


### PR DESCRIPTION
# Closes: n/a

## Goal
Reduce gem's size.

## Approach
1. Enumerate files to include in gem.
2. Retract `version.rb` (and use gemspec instead).
3. Update RDoc's `.document`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
