### PR TITLE
fix: signing_key

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,3 +1,4 @@
+name: Release
 on:
   push:
     tags:

--- a/hit_counter.gemspec
+++ b/hit_counter.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/FoveaCentral/hit_counter'
   s.authors = ['Roderick Monje']
   s.cert_chain = ['certs/ivanoblomov.pem']
+  s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME.end_with?('gem')
 
   s.add_dependency 'addressable'
   s.add_dependency 'mongoid'


### PR DESCRIPTION
# Re: #58

## Goal
Fix pushing gem.

## Approach
1. Restore `signing_key`.
2. Name release action.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
