### PR TITLE
CI: replaced Code Climate with Qlty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Test
 on:
   push:
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write
 jobs:
   test:
     environment: staging
@@ -22,10 +24,12 @@ jobs:
     - run: bundle exec rake
     - run: bundle exec rubocop
     - run: bundle exec inch --pedantic
-    - uses: amancevice/setup-code-climate@0daf2985a225e8ac15975b4d233010e94d65b76a
+    - uses: qltysh/qlty-action/coverage@v1
       with:
-        cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
-    - run: cc-test-reporter after-build --coverage-input-type lcov
+        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
+        command: after-build --coverage-input-type lcov
+        oidc: true
+        files: coverage/lcov.info
     - uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HitCounter
 
 [![Build status](https://github.com/FoveaCentral/hit_counter/workflows/test/badge.svg)](https://github.com/FoveaCentral/hit_counter/actions/workflows/test.yml)
-[![Code Climate](https://codeclimate.com/github/FoveaCentral/hit_counter.svg)](https://codeclimate.com/github/FoveaCentral/hit_counter)
+[![Maintainability](https://qlty.sh/gh/FoveaCentral/projects/vaccinesignup/maintainability.svg)](https://qlty.sh/gh/FoveaCentral/projects/vaccinesignup)[![Coverage Status](https://coveralls.io/repos/github/FoveaCentral/vaccinesignup/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/FoveaCentral/vaccinesignup?branch=main)
 [![Coveralls](https://coveralls.io/repos/FoveaCentral/hit_counter/badge.svg?branch=master&service=github)](https://coveralls.io/github/FoveaCentral/hit_counter?branch=master)
 [![CII Best Practices](https://www.bestpractices.dev/projects/5375/badge)](https://www.bestpractices.dev/en/projects/5375)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FoveaCentral/hit_counter/badge)](https://scorecard.dev/viewer/?uri=github.com/FoveaCentral/hit_counter)


### PR DESCRIPTION
# Closes: n/a

## Goal
Fixed failures in `master` by replacing the deprecated Code Climate with its successor Qlty.

## Approach
Following approach in [Migrating Coverage Uploads](https://docs.qlty.sh/migration/coverage):
1. Replaced Code Climate block in `test.yml` with:
    ```yaml
    - uses: qltysh/qlty-action/coverage@v1
      with:
        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
        command: after-build --coverage-input-type lcov
        oidc: true
        files: coverage/lcov.info
    ```
2. Updated permissions to:
    ```yaml
    permissions:
      contents: read
      id-token: write
    ```
3. Updated badge.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
