### PR TITLE
fix: rubocop -A

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,9 +24,7 @@ require 'rake'
 
 # load rake tasks
 # https://dev.to/cassidycodes/how-to-test-rake-tasks-with-rspec-without-rails-3mhb
-# rubocop:disable Style/OneClassPerFile
 module TaskFormat
-  # rubocop:enable Style/OneClassPerFile
   extend ActiveSupport::Concern
 
   included do


### PR DESCRIPTION
# Closes: n/a

## Goal
Fix Rubocop failure in master:
```ruby
Offenses:

spec/spec_helper.rb:27:1: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/OneClassPerFile.
# rubocop:disable Style/OneClassPerFile
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

9 files inspected, 1 offense detected, 1 offense autocorrectable
```

## Approach
1. `rubocop -A`

Signed-off-by: Roderick Monje <rod@foveacentral.com>
