### PR TITLE
conf: moved SimpleCov.start to helper

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -12,4 +12,3 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
     SimpleCov::Formatter::LcovFormatter
   ]
 )
-SimpleCov.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'hit_counter'
 
 Mongoid.load! 'config/mongoid.yml', :test
 Mongo::Logger.logger.level = Logger::WARN
+SimpleCov.start
 
 # Stub Rails root during tests.
 module Rails


### PR DESCRIPTION
# Closes: n/a

## Goal
Fix warning:
> [DEPRECATION] Calling `SimpleCov.start` from `.simplecov` is deprecated and will be removed in a future release. `.simplecov` should contain configuration only; move the `SimpleCov.start` call into your `spec_helper.rb` / `test_helper.rb`. Coverage tracking still begins for backward compatibility, but a future release will require the explicit `SimpleCov.start` from a test helper. See https://github.com/simplecov-ruby/simplecov/issues/581.

## Approach
1. (See above.)

Signed-off-by: Roderick Monje <rod@foveacentral.com>
